### PR TITLE
SLING-11915 caconfig-mock-plugin: Order of collection items may be lost in writeConfigurationCollection

### DIFF
--- a/src/main/java/org/apache/sling/testing/mock/caconfig/ConfigurationPersistHelper.java
+++ b/src/main/java/org/apache/sling/testing/mock/caconfig/ConfigurationPersistHelper.java
@@ -19,7 +19,7 @@
 package org.apache.sling.testing.mock.caconfig;
 
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -81,7 +81,7 @@ class ConfigurationPersistHelper {
      */
     void writeConfigurationCollection(@NotNull String configName, @NotNull Collection<@NotNull Map<String, Object>> values) {
         // split each collection item map in it's parts
-        Map<String, ConfigurationDataParts> partsCollection = new HashMap<>();
+        Map<String, ConfigurationDataParts> partsCollection = new LinkedHashMap<>();
         int index = 0;
         for (Map<String, Object> map : values) {
             partsCollection.put("item" + (index++), new ConfigurationDataParts(map));

--- a/src/test/java/org/apache/sling/testing/mock/caconfig/MockContextAwareConfigTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/caconfig/MockContextAwareConfigTest.java
@@ -92,6 +92,30 @@ public class MockContextAwareConfigTest {
     }
 
     @Test
+    public void testCollectionConfig_DifferentOrder() {
+        MockContextAwareConfig.writeConfigurationCollection(context, "/content/region/site", ListConfig.class, ImmutableList.of(
+                ImmutableMap.<String,Object>of("stringParam", "value2"),
+                ImmutableMap.<String,Object>of("stringParam", "value3"),
+                ImmutableMap.<String,Object>of("stringParam", "value1")));
+
+        Collection<ListConfig> config = getConfigCollection(ListConfig.class);
+        assertEquals(3, config.size());
+        Iterator<ListConfig> items = config.iterator();
+
+        ListConfig item1 = items.next();
+        assertEquals("value2", item1.stringParam());
+        assertEquals(5, item1.intParam());
+
+        ListConfig item2 = items.next();
+        assertEquals("value3", item2.stringParam());
+        assertEquals(5, item2.intParam());
+
+        ListConfig item3 = items.next();
+        assertEquals("value1", item3.stringParam());
+        assertEquals(5, item3.intParam());
+    }
+
+    @Test
     public void testNestedSingletonConfig() {
         MockContextAwareConfig.writeConfiguration(context, "/content/region/site", NestedConfig.class,
                 "stringParam", "value1",


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SLING-11915